### PR TITLE
Fix for  #6 - Big amount of sql queries in GroupAdmin

### DIFF
--- a/groupadmin_users/admin.py
+++ b/groupadmin_users/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.models import Group
+from django.contrib.auth.admin import GroupAdmin as GroupAdminDefault
 
 from groupadmin_users.forms import GroupAdminForm
 
@@ -9,7 +10,7 @@ admin.site.unregister(Group)
 
 
 # Create a new Group admin.
-class GroupAdmin(admin.ModelAdmin):
+class GroupAdmin(GroupAdminDefault):
     # Use our custom form.
     form = GroupAdminForm
     # Filter permissions horizontal as well.


### PR DESCRIPTION
` groupadmin_users.admin.GroupAdmin` class produced 260+ sql queries (exact count depends on amount of available permissions) during the load of admin page for a group because every Permission item has related items in `content_type` table.

This problem is already fixed in django, so inheritance from django's original GroupAdmin solves the problem.

I also tried to add a test case for this but I couldn't use `assertNumQueries` because of different versions of django the number of queries were different. So I added and  used `withAssertNumQueriesLessThen` (it's a variation of how `assertNumQueries` works).
I hope it's ok.
