### PR TITLE
Fix Issue 12 - In Django 5.2 the label ("Users") is rendered after the select boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,7 @@
 ### Changed
 
 - Fix number of SQL queries, by Dmitry Plevkov [@wwarne](https://github.com/wwarne).
+
+## [0.3.5] - 2025-12-16
+
+- Fix users' label rendering in the detail view of the group. Issue: https://github.com/Microdisseny/django-groupadmin-users/issues/12

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 from setuptools import find_packages
 
-VERSION = '0.3.4'
+VERSION = '0.3.5'
 
 CLASSIFIERS = [
     'Framework :: Django',


### PR DESCRIPTION
Fix for https://github.com/Microdisseny/django-groupadmin-users/issues/12